### PR TITLE
specify direct convolution in filterinf

### DIFF
--- a/physoce/tseries.py
+++ b/physoce/tseries.py
@@ -94,7 +94,7 @@ Output: the filtered time series
     
     # normalize weights and convolve
     wtsn = wts*sum(wts)**-1 # normalize weights so sum = 1
-    xf = signal.convolve(x,wtsn[:,np.newaxis],mode='same')  
+    xf = signal.convolve(x,wtsn[:,np.newaxis],mode='same',method='direct')  
     
     # note: np.convolve may be faster 
     # http://scipy.github.io/old-wiki/pages/Cookbook/ApplyFIRFilter


### PR DESCRIPTION
The automatic method in signal.convolve uses FFT for large series (>~100000). If this time series has NaN's the FFT convolution returns a series that is all NaNs. To avoid this, the direct convolution method is now specified in the _filt() function to make it more robust, even if it is slower for large data sets.